### PR TITLE
Docker compose updated - without obsolete atribute 'version'

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   db:
     image: postgres:${POSTGRES_VERSION_TAG}


### PR DESCRIPTION
Testing a new feature: updating the docker compose file to be up-to-date with the Docker Compose documentation.